### PR TITLE
Moved Observables from onStart() to onViewCreated().

### DIFF
--- a/app/src/main/java/com/ykode/rxsample/MainActivity.java
+++ b/app/src/main/java/com/ykode/rxsample/MainActivity.java
@@ -1,6 +1,7 @@
 package com.ykode.rxsample;
 
 import android.graphics.Color;
+import android.support.annotation.Nullable;
 import android.support.v7.app.ActionBarActivity;
 import android.support.v7.app.ActionBar;
 import android.support.v4.app.Fragment;
@@ -42,37 +43,7 @@ public class MainActivity extends ActionBarActivity {
     protected void onStart() {
         super.onStart();
 
-        final Pattern emailPattern = Pattern.compile(
-                "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@"
-                + "[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$");
 
-        EditText userNameEdit = (EditText) findViewById(R.id.edtUserName);
-        EditText emailEdit = (EditText) findViewById(R.id.edtEmail);
-
-        Observable<Boolean> userNameValid = WidgetObservable.text(userNameEdit)
-                .map(e -> e.text())
-                .map(t -> t.length() > 4);
-
-        Observable<Boolean> emailValid = WidgetObservable.text(emailEdit)
-                .map(e -> e.text())
-                .map(t -> emailPattern.matcher(t).matches());
-
-        emailValid.distinctUntilChanged()
-                .doOnNext( b -> Log.d("[Rx]", "Email " + (b ? "Valid" : "Invalid")))
-                .map(b -> b ? Color.BLACK : Color.RED)
-                .subscribe(color -> emailEdit.setTextColor(color));
-
-        userNameValid.distinctUntilChanged()
-                .doOnNext( b -> Log.d("[Rx]", "Uname " + (b ? "Valid" : "Invalid")))
-                .map(b -> b ? Color.BLACK : Color.RED)
-                .subscribe(color -> userNameEdit.setTextColor(color));
-
-        Button registerButton = (Button) findViewById(R.id.buttonRegister);
-        Observable<Boolean> registerEnabled =
-                Observable.combineLatest(userNameValid, emailValid, (a,b) -> a && b);
-        registerEnabled.distinctUntilChanged()
-                .doOnNext( b -> Log.d("[Rx]", "Button " + (b ? "Enabled" : "Disabled")))
-                .subscribe( enabled -> registerButton.setEnabled(enabled));
     }
 
     @Override
@@ -102,6 +73,10 @@ public class MainActivity extends ActionBarActivity {
      */
     public static class PlaceholderFragment extends Fragment {
 
+        private EditText userNameEdit;
+        private EditText emailEdit;
+        private Button registerButton;
+
         public PlaceholderFragment() {
         }
 
@@ -109,7 +84,44 @@ public class MainActivity extends ActionBarActivity {
         public View onCreateView(LayoutInflater inflater, ViewGroup container,
                                  Bundle savedInstanceState) {
             View rootView = inflater.inflate(R.layout.fragment_main, container, false);
+
+            userNameEdit = (EditText) rootView.findViewById(R.id.edtUserName);
+            emailEdit = (EditText) rootView.findViewById(R.id.edtEmail);
+            registerButton = (Button) rootView.findViewById(R.id.buttonRegister);
+
             return rootView;
+        }
+
+        @Override
+        public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+            super.onViewCreated(view, savedInstanceState);
+            final Pattern emailPattern = Pattern.compile(
+                    "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@"
+                            + "[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$");
+
+            Observable<Boolean> userNameValid = WidgetObservable.text(userNameEdit)
+                    .map(e -> e.text())
+                    .map(t -> t.length() > 4);
+
+            Observable<Boolean> emailValid = WidgetObservable.text(emailEdit)
+                    .map(e -> e.text())
+                    .map(t -> emailPattern.matcher(t).matches());
+
+            emailValid.distinctUntilChanged()
+                    .doOnNext( b -> Log.d("[Rx]", "Email " + (b ? "Valid" : "Invalid")))
+                    .map(b -> b ? Color.BLACK : Color.RED)
+                    .subscribe(color -> emailEdit.setTextColor(color));
+
+            userNameValid.distinctUntilChanged()
+                    .doOnNext( b -> Log.d("[Rx]", "Uname " + (b ? "Valid" : "Invalid")))
+                    .map(b -> b ? Color.BLACK : Color.RED)
+                    .subscribe(color -> userNameEdit.setTextColor(color));
+
+            Observable<Boolean> registerEnabled =
+                    Observable.combineLatest(userNameValid, emailValid, (a,b) -> a && b);
+            registerEnabled.distinctUntilChanged()
+                    .doOnNext( b -> Log.d("[Rx]", "Button " + (b ? "Enabled" : "Disabled")))
+                    .subscribe( enabled -> registerButton.setEnabled(enabled));
         }
     }
 }


### PR DESCRIPTION
Instantiating Observables in onStart() causes them to be duplicated if
the app is ever sent to the background and then resumed. State
information is also lost on config changes. Moving them to
PlaceholderFragment’s onViewCreated() solves these issues.
